### PR TITLE
Pin Elixir requirement version to 1.13 max

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EexToHeex.MixProject do
     [
       app: :eextoheex,
       version: "0.1.5",
-      elixir: "~> 1.11",
+      elixir: "~> 1.11 < 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: escript(),


### PR DESCRIPTION
Since `EEx.Tokenizer.tokenize/4` has been removed and replaced by a very similar but not similar enough `EEx.tokenize/2` we should explicitly make it require a version between Elixir 1.11 and 1.13.

I would love to keep digging what did change between versions to help to make it work on newer versions of Elixir.