### PR TITLE
Fix exceptions and update conventions

### DIFF
--- a/lib/eextoheex.ex
+++ b/lib/eextoheex.ex
@@ -282,7 +282,7 @@ defmodule EexToHeex do
         end
       )
 
-    "<.form :let={#{Macro.to_string(f)}} for=#{brace_wrap(Macro.to_string(changeset))} action={~p#{brace_wrap(Macro.to_string(url))}}#{extras}>"
+    "<.form :let={#{Macro.to_string(f)}} for=#{brace_wrap(Macro.to_string(changeset))} action={#{brace_wrap(Macro.to_string(url))}}#{extras}>"
   end
 
   defp find_livecomponent_tags(accum, [t = {:expr, ~c"=", txt, _opts} | rest]) do

--- a/lib/eextoheex.ex
+++ b/lib/eextoheex.ex
@@ -282,7 +282,7 @@ defmodule EexToHeex do
         end
       )
 
-    "<.form let={#{Macro.to_string(f)}} for=#{brace_wrap(Macro.to_string(changeset))} url=#{brace_wrap(Macro.to_string(url))}#{extras}>"
+    "<.form :let={#{Macro.to_string(f)}} for=#{brace_wrap(Macro.to_string(changeset))} action={~p#{brace_wrap(Macro.to_string(url))}}#{extras}>"
   end
 
   defp find_livecomponent_tags(accum, [t = {:expr, ~c"=", txt, _opts} | rest]) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EexToHeex.MixProject do
     [
       app: :eextoheex,
       version: "0.1.5",
-      elixir: "~> 1.11",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       escript: escript(),

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule EexToHeex.MixProject do
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
       {:html_entities, "~> 0.5"},
       {:phoenix_live_view, "~> 0.17.5", runtime: false},
-      {:briefly, "~> 0.3"},
+      {:briefly, "~> 0.5.1"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "briefly": {:hex, :briefly, "0.3.0", "16e6b76d2070ebc9cbd025fa85cf5dbaf52368c4bd896fb482b5a6b95a540c2f", [:mix], [], "hexpm", "c6ebf8fc3dcd4950dd10c03e953fb4f553a8bcf0ff4c8c40d71542434cd7e046"},
+  "briefly": {:hex, :briefly, "0.5.1", "ee10d48da7f79ed2aebdc3e536d5f9a0c3e36ff76c0ad0d4254653a152b13a8a", [:mix], [], "hexpm", "bd684aa92ad8b7b4e0d92c31200993c4bc1469fc68cd6d5f15144041bd15cb57"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.15", "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm", "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},
   "ex_doc": {:hex, :ex_doc, "0.25.3", "3edf6a0d70a39d2eafde030b8895501b1c93692effcbd21347296c18e47618ce", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "9ebebc2169ec732a38e9e779fd0418c9189b3ca93f4a676c961be6c1527913f5"},
   "html_entities": {:hex, :html_entities, "0.5.2", "9e47e70598da7de2a9ff6af8758399251db6dbb7eebe2b013f2bbd2515895c3c", [:mix], [], "hexpm", "c53ba390403485615623b9531e97696f076ed415e8d8058b1dbaa28181f4fdcc"},

--- a/test/eextoheex_test.exs
+++ b/test/eextoheex_test.exs
@@ -104,14 +104,14 @@ defmodule EexToHeexTest do
 
       out_templ = """
       <form>
-        <.form let={f} for={@changeset} url="#" phx-submit="save" phx-change="change">
+        <.form :let={f} for={@changeset} action={~p"#"} phx-submit="save" phx-change="change">
           <%= PlatformWeb.Patterns.card_buttons() do %>
             <button class="button-primary" phx-action="Save" phx_disable_with="Saving...">Add Postcode</button>
           <% end %>
         </.form>
       </form>
       </form> <!-- spurious closing tag; there are no open forms here -->
-      <.form let={foobar2} for={@changeset} url="#" phx-submit="save" phx-change={if foo do
+      <.form :let={foobar2} for={@changeset} action={~p"#"} phx-submit="save" phx-change={if foo do
         bar
       else
         amp
@@ -123,7 +123,7 @@ defmodule EexToHeexTest do
           </form>
         <% end %>
       </.form>
-      <.form let={bar} for={@changeset} url="#">
+      <.form :let={bar} for={@changeset} action={~p"#"}>
         ...
       </.form>
       """

--- a/test/eextoheex_test.exs
+++ b/test/eextoheex_test.exs
@@ -104,14 +104,14 @@ defmodule EexToHeexTest do
 
       out_templ = """
       <form>
-        <.form :let={f} for={@changeset} action={~p"#"} phx-submit="save" phx-change="change">
+        <.form :let={f} for={@changeset} action={"#"} phx-submit="save" phx-change="change">
           <%= PlatformWeb.Patterns.card_buttons() do %>
             <button class="button-primary" phx-action="Save" phx_disable_with="Saving...">Add Postcode</button>
           <% end %>
         </.form>
       </form>
       </form> <!-- spurious closing tag; there are no open forms here -->
-      <.form :let={foobar2} for={@changeset} action={~p"#"} phx-submit="save" phx-change={if foo do
+      <.form :let={foobar2} for={@changeset} action={"#"} phx-submit="save" phx-change={if foo do
         bar
       else
         amp
@@ -123,7 +123,7 @@ defmodule EexToHeexTest do
           </form>
         <% end %>
       </.form>
-      <.form :let={bar} for={@changeset} action={~p"#"}>
+      <.form :let={bar} for={@changeset} action={"#"}>
         ...
       </.form>
       """


### PR DESCRIPTION
@addrummond 

Fixes exceptions that occur if you run it with the lastest Elixir version (e.g. `1.16`) where the structure of the tokens changed from e.g. `{:expr, line, column, ~c"=", text}` to `{:expr, ~c"=", text, %{line: line, column: column}}`

It also updates the form fields from `let={form}` to `:let={form}` and `url="#"` to `action={~p"#"}`